### PR TITLE
Handle object being destroyed before endResize debounce

### DIFF
--- a/addon/main.js
+++ b/addon/main.js
@@ -66,9 +66,11 @@ export default Ember.Mixin.create({
    * @private
    */
   _endResize: function (event) {
-    this.set('resizing', false);
-    if (this.has('resizeEnd')) {
-      this.trigger('resizeEnd', event);
+    if (!this.get('isDestroyed')) {
+      this.set('resizing', false);
+      if (this.has('resizeEnd')) {
+        this.trigger('resizeEnd', event);
+      }
     }
   }
 });


### PR DESCRIPTION
A component that utilizes this mixin might be destroyed shortly after resizing, but before `_endResize` has finished debouncing. This results in the `_endResize` function being run when the object is already destroyed, causing an `Uncaught Error: Assertion Failed: calling set on destroyed object` when it tries to set `resizing` to false.
